### PR TITLE
change: 使用原生事件代替 vue-moveable 处理字幕拖拽

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "lrc-file-parser": "^1.0.7",
     "plyr": "^3.6.7",
     "quasar": "^1.15.12",
-    "vue-moveable": "^1.8.10",
     "vue-plyr": "^6.0.4",
     "vue-slider-component": "^3.2.11",
     "vue-socket.io": "^3.0.10",

--- a/src/components/LyricsBar.vue
+++ b/src/components/LyricsBar.vue
@@ -1,45 +1,88 @@
 <template>
-  <Moveable v-bind="moveable" @drag="handleDrag">
-    <q-card>
+    <q-card
+      id="draggable"
+      @mousedown="onCursorDown"
+      @mouseup="onCursorUp"
+      @touchstart="onCursorDown"
+      @touchend="onCursorUp"
+    >
         <div id="lyricsBar" class="text-center text-h6 text-bold ellipsis-2-lines text-purple q-mb-md absolute-bottom">
             <span id="lyric">
               {{currentLyric}}
             </span>
         </div>
     </q-card>
-  </Moveable>
 </template>
 
 <script>
-import Moveable from "vue-moveable";
 import { mapState } from 'vuex'
+
+const onCursorMove = (that) => (ev) => {
+  if (!that.beTouched) { return }
+
+  // ev.preventDefault()
+  const touch = that.getTouch(ev)
+
+  // 计算 element 新位置坐标
+  const eleX = touch.clientX - that.startX
+  const eleY = touch.clientY - that.startY
+
+  that.draggable.style.left = eleX + 'px'
+  that.draggable.style.top = eleY + 'px'
+
+}
 
 export default {
   name: 'LyricsBar',
-
-  components: {
-    Moveable,
-  },
 
   computed: {
     ...mapState('AudioPlayer', [
       'currentLyric'
     ]),
+
+    draggable() {
+      return document.getElementById('draggable')
+    }
   },
 
   data () {
     return {
-      moveable: {
-        draggable: true,
-      },
+      beTouched: false,
+
+      // 鼠标按下时的位置
+      startX: 0,
+      startY: 0
     }
   },
 
   methods: {
-    handleDrag({ target, transform }) {
-      target.style.transform = transform;
+    /**
+     * @param {TouchEvent|MouseEvent} ev
+     */
+    getTouch(ev) {
+      return ev.touches ? ev.touches[0] : ev;
     },
+
+    onCursorDown(ev) {
+      ev.preventDefault()
+      this.beTouched = true
+
+      // 移动端使用 ev.touches[0]
+      const touch = this.getTouch(ev)
+      this.startX = touch.clientX - this.draggable.offsetLeft
+      this.startY = touch.clientY - this.draggable.offsetTop
+    },
+
+    onCursorUp(ev) {
+      ev.preventDefault()
+      this.beTouched = false
+    }
   },
+
+  mounted() {
+    addEventListener('mousemove', onCursorMove(this), false)
+    addEventListener('touchmove', onCursorMove(this), false)
+  }
 }
 </script>
 
@@ -49,5 +92,7 @@ export default {
   }
   #lyricsBar {
     background-color: rgba($grey-4, $alpha: 0.6);
+    min-width: 1vw;
+    position: absolute;
   }
 </style>


### PR DESCRIPTION
通过这个变更，可以使整个 vendor 体积减小 ~20%

就为了让字幕可以在屏幕内拖动，引入 200k 的模块有点不值得

变更前：
![image.png](https://i.loli.net/2021/09/25/D7IX2MfaW6h9sUi.png)

变更后：
![image.png](https://i.loli.net/2021/09/25/psJcz476L8PCrqV.png)